### PR TITLE
Adapt library to pass clippy::pedantic

### DIFF
--- a/src/compact_bytestrings.rs
+++ b/src/compact_bytestrings.rs
@@ -41,6 +41,7 @@ impl CompactBytestrings {
     /// # use compact_strings::CompactBytestrings;
     /// let mut cmpbytes = CompactBytestrings::new();
     /// ```
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             data: Vec::new(),
@@ -55,8 +56,8 @@ impl CompactBytestrings {
     /// - `capacity_meta`: The capacity of the meta vector where the starting indices and lengths
     /// of the bytestrings are stored.
     ///
-    /// The [`CompactBytestrings`] will be able to hold at least *data_capacity* bytes worth of bytestrings
-    /// without reallocating the data vector, and at least *capacity_meta* of starting indices and
+    /// The [`CompactBytestrings`] will be able to hold at least *`data_capacity`* bytes worth of bytestrings
+    /// without reallocating the data vector, and at least *`capacity_meta`* of starting indices and
     /// lengths without reallocating the meta vector. This method is allowed to allocate for more bytes
     /// than the capacities. If a capacity is 0, the vector will not allocate.
     ///
@@ -77,6 +78,7 @@ impl CompactBytestrings {
     /// assert!(cmpbytes.capacity() >= 20);
     /// assert!(cmpbytes.capacity_meta() >= 3);
     /// ```
+    #[must_use]
     pub fn with_capacity(data_capacity: usize, capacity_meta: usize) -> Self {
         Self {
             data: Vec::with_capacity(data_capacity),
@@ -124,6 +126,7 @@ impl CompactBytestrings {
     /// assert_eq!(cmpbytes.get(2), Some(b"Three".as_slice()));
     /// assert_eq!(cmpbytes.get(3), None);
     /// ```
+    #[must_use]
     pub fn get(&self, index: usize) -> Option<&[u8]> {
         let (start, len) = self.meta.get(index)?.as_tuple();
         if cfg!(feature = "no_unsafe") {
@@ -153,6 +156,7 @@ impl CompactBytestrings {
     ///     assert_eq!(cmpbytes.get_unchecked(2), b"Three".as_slice());
     /// }
     /// ```
+    #[must_use]
     #[cfg(not(feature = "no_unsafe"))]
     pub unsafe fn get_unchecked(&self, index: usize) -> &[u8] {
         let (start, len) = self.meta.get_unchecked(index).as_tuple();
@@ -173,6 +177,7 @@ impl CompactBytestrings {
     /// assert_eq!(cmpbytes.len(), 3);
     /// ```
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.meta.len()
     }
@@ -190,6 +195,7 @@ impl CompactBytestrings {
     /// assert!(!cmpbytes.is_empty());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -206,6 +212,7 @@ impl CompactBytestrings {
     /// assert!(cmpbytes.capacity() >= 20);
     /// ```
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.data.capacity()
     }
@@ -226,6 +233,7 @@ impl CompactBytestrings {
     /// assert!(cmpbytes.capacity_meta() > 3);
     /// ```
     #[inline]
+    #[must_use]
     pub fn capacity_meta(&self) -> usize {
         self.meta.capacity()
     }
@@ -442,7 +450,7 @@ impl CompactBytestrings {
         }
 
         if cfg!(feature = "no_unsafe") {
-            self.data.copy_within(start + len..inner_len, start)
+            self.data.copy_within(start + len..inner_len, start);
         } else {
             unsafe {
                 let ptr = self.data.as_mut_ptr().add(start);
@@ -484,7 +492,7 @@ impl Clone for CompactBytestrings {
         let mut data = Vec::with_capacity(self.meta.iter().map(|m| m.len).sum());
         let mut meta = Vec::with_capacity(self.meta.len());
 
-        for bytes in self.iter() {
+        for bytes in self {
             meta.push(Metadata {
                 start: data.len(),
                 len: bytes.len(),
@@ -556,6 +564,7 @@ impl Index<usize> for CompactBytestrings {
 /// assert_eq!(iter.next(), Some(b"Three".as_slice()));
 /// assert_eq!(iter.next(), None);
 /// ```
+#[must_use = "Iterators are lazy and must be consumed to be useful"]
 pub struct Iter<'a> {
     inner: &'a CompactBytestrings,
     iter: core::slice::Iter<'a, Metadata>,

--- a/src/compact_bytestrings.rs
+++ b/src/compact_bytestrings.rs
@@ -564,7 +564,7 @@ impl Index<usize> for CompactBytestrings {
 /// assert_eq!(iter.next(), Some(b"Three".as_slice()));
 /// assert_eq!(iter.next(), None);
 /// ```
-#[must_use = "Iterators are lazy and must be consumed to be useful"]
+#[must_use = "Iterators are lazy and do nothing unless consumed"]
 pub struct Iter<'a> {
     inner: &'a CompactBytestrings,
     iter: core::slice::Iter<'a, Metadata>,

--- a/src/compact_strings.rs
+++ b/src/compact_strings.rs
@@ -497,7 +497,7 @@ impl Index<usize> for CompactStrings {
 /// assert_eq!(iter.next(), Some("Three"));
 /// assert_eq!(iter.next(), None);
 /// ```
-#[must_use = "Iterators are lazy and must be consumed to be useful"]
+#[must_use = "Iterators are lazy and do nothing unless consumed"]
 pub struct Iter<'a> {
     inner: &'a CompactStrings,
     iter: core::slice::Iter<'a, Metadata>,

--- a/src/compact_strings.rs
+++ b/src/compact_strings.rs
@@ -41,6 +41,7 @@ impl CompactStrings {
     /// # use compact_strings::CompactStrings;
     /// let mut cmpstrs = CompactStrings::new();
     /// ```
+    #[must_use]
     pub const fn new() -> Self {
         Self(CompactBytestrings::new())
     }
@@ -52,8 +53,8 @@ impl CompactStrings {
     /// - `capacity_meta`: The capacity of the meta vector where the starting indices and lengths
     /// of the strings are stored.
     ///
-    /// The [`CompactStrings`] will be able to hold at least *data_capacity* bytes worth of strings
-    /// without reallocating the data vector, and at least *capacity_meta* of starting indices and
+    /// The [`CompactStrings`] will be able to hold at least *`data_capacity`* bytes worth of strings
+    /// without reallocating the data vector, and at least *`capacity_meta`* of starting indices and
     /// lengths without reallocating the meta vector. This method is allowed to allocate for more bytes
     /// than the capacities. If a capacity is 0, the vector will not allocate.
     ///
@@ -74,6 +75,7 @@ impl CompactStrings {
     /// assert!(cmpstrs.capacity() >= 20);
     /// assert!(cmpstrs.capacity_meta() >= 3);
     /// ```
+    #[must_use]
     pub fn with_capacity(data_capacity: usize, capacity_meta: usize) -> Self {
         Self(CompactBytestrings::with_capacity(
             data_capacity,
@@ -100,7 +102,7 @@ impl CompactStrings {
     where
         S: Deref<Target = str>,
     {
-        self.0.push(string.as_bytes())
+        self.0.push(string.as_bytes());
     }
 
     /// Returns a reference to the string stored in the [`CompactStrings`] at that position.
@@ -118,6 +120,7 @@ impl CompactStrings {
     /// assert_eq!(cmpstrs.get(2), Some("Three"));
     /// assert_eq!(cmpstrs.get(3), None);
     /// ```
+    #[must_use]
     pub fn get(&self, index: usize) -> Option<&str> {
         let bytes = self.0.get(index)?;
         if cfg!(feature = "no_unsafe") {
@@ -147,6 +150,7 @@ impl CompactStrings {
     ///     assert_eq!(cmpstrs.get_unchecked(2), "Three");
     /// }
     /// ```
+    #[must_use]
     #[cfg(not(feature = "no_unsafe"))]
     pub unsafe fn get_unchecked(&self, index: usize) -> &str {
         let bytes = self.0.get_unchecked(index);
@@ -167,6 +171,7 @@ impl CompactStrings {
     /// assert_eq!(cmpstrs.len(), 3);
     /// ```
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -184,6 +189,7 @@ impl CompactStrings {
     /// assert!(!cmpstrs.is_empty());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -200,6 +206,7 @@ impl CompactStrings {
     /// assert!(cmpstrs.capacity() >= 20);
     /// ```
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.0.capacity()
     }
@@ -220,6 +227,7 @@ impl CompactStrings {
     /// assert!(cmpstrs.capacity_meta() > 3);
     /// ```
     #[inline]
+    #[must_use]
     pub fn capacity_meta(&self) -> usize {
         self.0.capacity_meta()
     }
@@ -401,7 +409,7 @@ impl CompactStrings {
     /// assert_eq!(cmpstrs.get(2), None);
     /// ```
     pub fn remove(&mut self, index: usize) {
-        self.0.remove(index)
+        self.0.remove(index);
     }
 
     /// Returns an iterator over the slice.
@@ -489,6 +497,7 @@ impl Index<usize> for CompactStrings {
 /// assert_eq!(iter.next(), Some("Three"));
 /// assert_eq!(iter.next(), None);
 /// ```
+#[must_use = "Iterators are lazy and must be consumed to be useful"]
 pub struct Iter<'a> {
     inner: &'a CompactStrings,
     iter: core::slice::Iter<'a, Metadata>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! assert_eq!(cmpstrs.get(2), None);
 //! ```
 #![no_std]
+#![warn(clippy::pedantic)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 extern crate alloc;
 


### PR DESCRIPTION
Pretty simple non-breaking change to add must_use everywhere and some semicolons.