### PR TITLE
Reduce duplication in Iter impls

### DIFF
--- a/src/compact_bytestrings.rs
+++ b/src/compact_bytestrings.rs
@@ -557,7 +557,7 @@ impl Index<usize> for CompactBytestrings {
 /// assert_eq!(iter.next(), None);
 /// ```
 pub struct Iter<'a> {
-    inner: &'a CompactBytestrings,
+    data: &'a [u8],
     iter: core::slice::Iter<'a, Metadata>,
 }
 
@@ -565,7 +565,7 @@ impl<'a> Iter<'a> {
     #[inline]
     pub fn new(inner: &'a CompactBytestrings) -> Self {
         Self {
-            inner,
+            data: &inner.data,
             iter: inner.meta.iter(),
         }
     }
@@ -578,9 +578,9 @@ impl<'a> Iterator for Iter<'a> {
         let (start, len) = self.iter.next()?.as_tuple();
 
         if cfg!(feature = "no_unsafe") {
-            self.inner.data.get(start..start + len)
+            self.data.get(start..start + len)
         } else {
-            unsafe { Some(self.inner.data.get_unchecked(start..start + len)) }
+            unsafe { Some(self.data.get_unchecked(start..start + len)) }
         }
     }
 
@@ -595,9 +595,9 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
         let (start, len) = self.iter.next_back()?.as_tuple();
 
         if cfg!(feature = "no_unsafe") {
-            self.inner.data.get(start..start + len)
+            self.data.get(start..start + len)
         } else {
-            unsafe { Some(self.inner.data.get_unchecked(start..start + len)) }
+            unsafe { Some(self.data.get_unchecked(start..start + len)) }
         }
     }
 }
@@ -616,7 +616,7 @@ impl<'a> IntoIterator for &'a CompactBytestrings {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        Self::IntoIter::new(self)
+        self.iter()
     }
 }
 


### PR DESCRIPTION
- Moves the `CompactStrings` `Iter` to be defined in terms of `CompactByteStrings` `Iter`.
- Stores only the `data` field of the `CompactByteStrings`, to reduce the type size of `Iter`.
- Deduplicates the `from_utf8` logic of `CompactStrings`