### PR TITLE
Simplify Clone impl

### DIFF
--- a/src/compact_bytestrings.rs
+++ b/src/compact_bytestrings.rs
@@ -481,18 +481,15 @@ impl CompactBytestrings {
 
 impl Clone for CompactBytestrings {
     fn clone(&self) -> Self {
-        let mut data = Vec::with_capacity(self.meta.iter().map(|m| m.len).sum());
-        let mut meta = Vec::with_capacity(self.meta.len());
-
-        for bytes in self.iter() {
-            meta.push(Metadata {
-                start: data.len(),
-                len: bytes.len(),
-            });
-            data.extend_from_slice(bytes);
+        Self {
+            data: self.data.clone(),
+            meta: self.meta.clone(),
         }
+    }
 
-        Self { data, meta }
+    fn clone_from(&mut self, source: &Self) {
+        self.data.clone_from(&source.data);
+        self.meta.clone_from(&source.meta)
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, Copy)]
 pub(crate) struct Metadata {
     pub(crate) start: usize,
     pub(crate) len: usize,


### PR DESCRIPTION
I couldn't see why Clone is implemented weirdly, so I implemented it just in terms of Vec::clone. This also adds clone_from, which is why I didn't use the derive macro.